### PR TITLE
Clean DropKit constructor

### DIFF
--- a/src/DropKit.sol
+++ b/src/DropKit.sol
@@ -12,9 +12,6 @@ import {DropShares} from "./DropShares.sol";
 import {DropConfig, DropVars, Recipient} from "./Types.sol";
 import {IDropKit} from "./interfaces/IDropKit.sol";
 
-// TODO remove
-import "forge-std/Test.sol";
-
 /// @title DropKit (Transparent Proxy Implementation)
 /// @author kelbels
 /// @dev Handles ERC20 token drops with vesting. Creation and claim fees are paid in the native chain token.
@@ -23,7 +20,9 @@ contract DropKit is Initializable, OwnableUpgradeable, IDropKit, DropShares {
     using SafeTransferLib for address;
 
     constructor() {
-        // _disableInitializers();
+        // Prevent the implementation contract from being initialized
+        // outside of the proxy context.
+        _disableInitializers();
     }
 
     function initialize(


### PR DESCRIPTION
## Summary
- remove leftover Test.sol import
- protect DropKit implementation with `_disableInitializers()`

## Testing
- `forge test -vvv` *(fails: forge not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68415d61786c832e92b61707126152ae